### PR TITLE
お気に入り/ブックマーク機能の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+rustfeed is a CLI RSS feed reader written in Rust. It fetches RSS/Atom feeds, stores articles in a local SQLite database, and provides commands to manage feeds and articles.
+
+## Common Commands
+
+### Development
+```bash
+# Build the project
+cargo build
+
+# Build for release (optimized)
+cargo build --release
+
+# Run the application
+cargo run
+
+# Run with arguments (e.g., add a feed)
+cargo run -- add https://blog.rust-lang.org/feed.xml
+
+# Check for errors without building
+cargo check
+
+# Run tests
+cargo test
+
+# Run a specific test
+cargo test test_fetch_feed
+
+# Generate and open documentation
+cargo doc --open
+
+# Generate documentation including private items
+cargo doc --no-deps --document-private-items
+```
+
+### Using the CLI
+```bash
+# Add a feed
+cargo run -- add <url> [--name "Custom Name"]
+
+# List all feeds
+cargo run -- list
+
+# Fetch articles from all feeds
+cargo run -- fetch
+
+# Show articles
+cargo run -- articles [--unread] [--limit 20]
+
+# Mark article as read
+cargo run -- read <article_id>
+
+# Remove a feed
+cargo run -- remove <feed_id>
+```
+
+## Architecture
+
+### Module Structure
+
+The application follows a clean modular architecture with clear separation of concerns:
+
+- **`main.rs`**: Entry point with CLI argument parsing using `clap`. Defines the `Commands` enum with all available subcommands and orchestrates the flow.
+- **`models/`**: Core data structures (`Feed` and `Article`) with their constructors. These are serializable with `serde` and represent the domain model.
+- **`db/`**: Database layer using SQLite via `rusqlite`. Handles all CRUD operations and persistence. Database file is stored at `~/.rustfeed/rustfeed.db`.
+- **`feed/`**: RSS/Atom feed fetching and parsing using `feed-rs` and `reqwest`. Converts external feed formats to internal data models.
+- **`commands/`**: Implementation of CLI commands, tying together the other modules and providing user-facing functionality with colored output.
+
+### Data Flow
+
+1. User invokes CLI command → parsed by `clap` in `main.rs`
+2. `main.rs` initializes `Database` and calls appropriate function in `commands/`
+3. `commands/` functions coordinate between `feed/` (for fetching) and `db/` (for storage)
+4. Results are displayed to user with colored output using `colored` crate
+
+### Database Schema
+
+**feeds table**:
+- `id` (INTEGER, PRIMARY KEY)
+- `url` (TEXT, UNIQUE, NOT NULL)
+- `title` (TEXT, NOT NULL)
+- `description` (TEXT, nullable)
+- `created_at` (TEXT, RFC3339 format)
+- `updated_at` (TEXT, RFC3339 format)
+
+**articles table**:
+- `id` (INTEGER, PRIMARY KEY)
+- `feed_id` (INTEGER, FOREIGN KEY → feeds.id, CASCADE DELETE)
+- `title` (TEXT, NOT NULL)
+- `url` (TEXT, nullable)
+- `content` (TEXT, nullable)
+- `published_at` (TEXT, RFC3339 format, nullable)
+- `is_read` (INTEGER, 0/1 boolean)
+- `created_at` (TEXT, RFC3339 format)
+- UNIQUE constraint on `(feed_id, url)` to prevent duplicates
+
+### Key Design Patterns
+
+- **Async/await**: Network operations use `tokio` async runtime for non-blocking I/O
+- **Error handling**: Uses `anyhow::Result` for error propagation with context
+- **Option types**: Leverages Rust's `Option<T>` for nullable fields instead of null pointers
+- **Ownership**: Functions take references (`&Database`, `&Feed`) to avoid unnecessary clones
+- **DateTime handling**: All timestamps stored as RFC3339 strings in SQLite, parsed to `chrono::DateTime<Utc>` in Rust
+
+### Important Implementation Details
+
+- The `feed::fetch_feed()` function returns articles with `feed_id = 0`; the caller must set the correct `feed_id` before inserting into the database
+- Articles use `INSERT OR IGNORE` to prevent duplicate entries based on the `(feed_id, url)` unique constraint
+- The codebase includes extensive rustdoc comments in Japanese for learning purposes
+- Error handling in `fetch_feeds` is resilient: individual feed failures don't stop processing other feeds
+- Feed deletion cascades to articles automatically via `ON DELETE CASCADE`
+
+## Code Style Notes
+
+- The codebase contains comprehensive rustdoc comments written in Japanese as educational material
+- Comments explain Rust concepts like ownership, borrowing, lifetimes, pattern matching, and traits
+- When adding new code, match the existing rustdoc style if contributing to this learning-focused codebase

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ A CLI RSS reader written in Rust.
 
 rustfeed is a command-line RSS feed reader designed to help you efficiently collect and manage information from multiple sources.
 
-## Features (Planned)
+## Features
 
-### Phase 1 (MVP)
-- [ ] Add/remove RSS feeds
-- [ ] Fetch and list articles
-- [ ] Mark articles as read/unread
-- [ ] Local SQLite database for persistence
+### Phase 1 (MVP) ✅
+- [x] Add/remove RSS feeds
+- [x] Fetch and list articles
+- [x] Mark articles as read/unread
+- [x] Local SQLite database for persistence
 
 ### Phase 2
 - [ ] Keyword filtering
-- [ ] Favorites/bookmarks
+- [x] Favorites/bookmarks
 - [ ] TUI (Terminal UI)
 
 ### Phase 3
@@ -51,9 +51,15 @@ rustfeed fetch
 
 # Show articles
 rustfeed articles
+rustfeed articles --unread  # Show unread articles only
 
 # Mark as read
 rustfeed read <article_id>
+
+# Favorites
+rustfeed favorite <article_id>    # Add to favorites
+rustfeed unfavorite <article_id>  # Remove from favorites
+rustfeed favorites                # Show favorite articles
 ```
 
 ## License

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,41 @@ enum Commands {
         /// 既読にする記事の ID
         id: i64,
     },
+
+    /// 記事をお気に入りに追加する
+    ///
+    /// # 使用例
+    /// ```bash
+    /// rustfeed favorite 1
+    /// ```
+    Favorite {
+        /// お気に入りにする記事の ID
+        id: i64,
+    },
+
+    /// 記事をお気に入りから削除する
+    ///
+    /// # 使用例
+    /// ```bash
+    /// rustfeed unfavorite 1
+    /// ```
+    Unfavorite {
+        /// お気に入りから削除する記事の ID
+        id: i64,
+    },
+
+    /// お気に入り記事を一覧表示する
+    ///
+    /// # 使用例
+    /// ```bash
+    /// rustfeed favorites
+    /// rustfeed favorites -l 10  # 10件まで
+    /// ```
+    Favorites {
+        /// 表示する記事数の上限（デフォルト: 20）
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+    },
 }
 
 // =============================================================================
@@ -227,6 +262,18 @@ async fn main() -> Result<()> {
 
         Commands::Read { id } => {
             commands::mark_as_read(&db, id)?;
+        }
+
+        Commands::Favorite { id } => {
+            commands::add_favorite(&db, id)?;
+        }
+
+        Commands::Unfavorite { id } => {
+            commands::remove_favorite(&db, id)?;
+        }
+
+        Commands::Favorites { limit } => {
+            commands::show_favorites(&db, limit)?;
         }
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -196,6 +196,11 @@ pub struct Article {
     /// `bool` は真偽値型で、`true` または `false` のみを取ります。
     pub is_read: bool,
 
+    /// お気に入りフラグ
+    ///
+    /// ユーザーが重要としてマークした記事を示します。
+    pub is_favorite: bool,
+
     /// この記事をデータベースに保存した日時
     pub created_at: DateTime<Utc>,
 }
@@ -241,7 +246,8 @@ impl Article {
             url,
             content,
             published_at,
-            is_read: false, // 新規記事は未読状態で作成
+            is_read: false,     // 新規記事は未読状態で作成
+            is_favorite: false, // 新規記事はお気に入りでない状態で作成
             created_at: Utc::now(),
         }
     }


### PR DESCRIPTION
## 概要
記事をお気に入りとして保存できる機能を実装しました（Issue #2）。

## 実装内容

### データベース
- `articles`テーブルに`is_favorite`カラムを追加（マイグレーション対応）
- `is_favorite`用のインデックスを追加（検索の高速化）

### データモデル
- `Article`構造体に`is_favorite: bool`フィールドを追加
- コンストラクタを更新（デフォルト値：`false`）

### データベース操作
- `add_favorite(id)` - 記事をお気に入りに追加
- `remove_favorite(id)` - 記事をお気に入りから削除
- `get_favorite_articles(limit)` - お気に入り記事の一覧を取得

### CLIコマンド
- `rustfeed favorite <id>` - 記事をお気に入りに追加
- `rustfeed unfavorite <id>` - 記事をお気に入りから削除
- `rustfeed favorites [-l <limit>]` - お気に入り記事を表示

### その他
- README更新（Phase 1完了、お気に入り機能の使用例を追加）
- CLAUDE.md追加（AI支援のためのプロジェクトガイド）

## テスト

すべてのテストが成功しています：
```bash
✅ cargo test
✅ cargo fmt
✅ cargo clippy
✅ cargo build --release
```

## 使用例

```bash
# フィードを追加して記事を取得
$ rustfeed add https://blog.rust-lang.org/feed.xml
$ rustfeed fetch

# 記事を表示
$ rustfeed articles -l 5

# お気に入りに追加
$ rustfeed favorite 1
Added to favorites: 1

# お気に入り一覧を表示
$ rustfeed favorites
Favorite Articles:

  [*] [1] 2025-12-19 What do people love about Rust?
      https://blog.rust-lang.org/...

# お気に入りから削除
$ rustfeed unfavorite 1
Removed from favorites: 1
```

## 学べるRustの概念
- データベースマイグレーション（ALTER TABLE）
- 既存コードの拡張パターン
- Option型とbool型の扱い
- SQLiteでのインデックス最適化

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)