### PR TITLE
キーワードフィルタリング機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ rustfeed is a command-line RSS feed reader designed to help you efficiently coll
 - [x] Local SQLite database for persistence
 
 ### Phase 2
-- [ ] Keyword filtering
+- [x] Keyword filtering
 - [x] Favorites/bookmarks
 - [ ] TUI (Terminal UI)
 
@@ -51,7 +51,10 @@ rustfeed fetch
 
 # Show articles
 rustfeed articles
-rustfeed articles --unread  # Show unread articles only
+rustfeed articles --unread              # Show unread articles only
+rustfeed articles --filter "rust"       # Filter by keyword
+rustfeed articles --filter "rust,cargo" # Filter by multiple keywords (OR)
+rustfeed articles --filter "rust" --unread -l 10  # Combine filters
 
 # Mark as read
 rustfeed read <article_id>

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -268,6 +268,7 @@ pub async fn fetch_feeds(db: &Database) -> Result<()> {
 /// * `db` - データベース接続
 /// * `unread_only` - true なら未読記事のみ表示
 /// * `limit` - 表示する最大件数
+/// * `filter` - キーワードフィルタ（カンマ区切りで複数指定可能）
 ///
 /// # 出力フォーマット
 ///
@@ -282,9 +283,14 @@ pub async fn fetch_feeds(db: &Database) -> Result<()> {
 ///
 /// - `[*]` = 未読（シアン色）
 /// - `[x]` = 既読（薄い色）
-pub fn show_articles(db: &Database, unread_only: bool, limit: usize) -> Result<()> {
+pub fn show_articles(
+    db: &Database,
+    unread_only: bool,
+    limit: usize,
+    filter: Option<&str>,
+) -> Result<()> {
     // 記事を取得
-    let articles = db.get_articles(unread_only, limit)?;
+    let articles = db.get_articles(unread_only, limit, filter)?;
 
     // 空の場合の処理
     if articles.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,9 +143,11 @@ enum Commands {
     ///
     /// # 使用例
     /// ```bash
-    /// rustfeed articles           # 全記事
-    /// rustfeed articles --unread  # 未読のみ
-    /// rustfeed articles -l 10     # 10件まで
+    /// rustfeed articles                    # 全記事
+    /// rustfeed articles --unread           # 未読のみ
+    /// rustfeed articles -l 10              # 10件まで
+    /// rustfeed articles --filter "rust"    # キーワードでフィルタ
+    /// rustfeed articles --filter "rust,cargo" --unread  # 複数キーワード、未読のみ
     /// ```
     Articles {
         /// 未読記事のみを表示するフラグ
@@ -155,6 +157,13 @@ enum Commands {
         /// 表示する記事数の上限（デフォルト: 20）
         #[arg(short, long, default_value = "20")]
         limit: usize,
+
+        /// キーワードフィルタ（カンマ区切りで複数指定可能、OR条件）
+        ///
+        /// タイトルまたは本文に指定したキーワードを含む記事のみを表示します。
+        /// 複数のキーワードをカンマで区切って指定すると、いずれかを含む記事を表示します。
+        #[arg(short, long)]
+        filter: Option<String>,
     },
 
     /// 記事を既読としてマークする
@@ -256,8 +265,12 @@ async fn main() -> Result<()> {
             commands::fetch_feeds(&db).await?;
         }
 
-        Commands::Articles { unread, limit } => {
-            commands::show_articles(&db, unread, limit)?;
+        Commands::Articles {
+            unread,
+            limit,
+            filter,
+        } => {
+            commands::show_articles(&db, unread, limit, filter.as_deref())?;
         }
 
         Commands::Read { id } => {


### PR DESCRIPTION
## 概要
記事をキーワードで検索できる機能を実装しました（Issue #1）。

## 実装内容

### 機能
- `articles`コマンドに`--filter`オプションを追加
- タイトルまたは本文にキーワードを含む記事を検索
- 複数キーワード対応（カンマ区切りでOR検索）
- 既存のフィルタ（`--unread`、`--limit`）と組み合わせ可能

### 実装詳細

#### CLI層 (`src/main.rs`)
- `Articles`コマンドに`filter: Option<String>`フィールド追加
- ヘルプメッセージに使用例を記載

#### コマンド層 (`src/commands/mod.rs`)
- `show_articles()`関数に`filter`パラメータ追加
- `Database::get_articles()`にフィルタを渡す

#### データベース層 (`src/db/mod.rs`)
- `get_articles()`メソッドを拡張
- SQLクエリを動的に構築（WHERE句にLIKE条件を追加）
- 複数キーワードの場合、各キーワードに対してOR条件を生成
- パラメータ化クエリでSQLインジェクション対策

### その他
- README更新（Phase 2のKeyword filteringを完了、使用例追加）

## テスト

すべてのテストが成功しています：
```bash
✅ cargo test
✅ cargo fmt
✅ cargo clippy
✅ cargo build --release
```

## 使用例

### 単一キーワード検索
```bash
$ rustfeed articles --filter "rust"
Articles:

  [*] [1] 2025-12-19 What do people love about Rust?
  [*] [3] 2025-12-11 Announcing Rust 1.92.0
  ...
```

### 複数キーワード検索（OR条件）
```bash
$ rustfeed articles --filter "sponsor,musl"
Articles:

  [*] [4] 2025-12-08 Making it easier to sponsor Rust contributors
  [*] [6] 2025-12-05 Updating Rust's Linux musl targets to 1.2.5
  ...
```

### フィルタの組み合わせ
```bash
$ rustfeed articles --filter "rust" --unread -l 10
Unread Articles:

  [*] [1] 2025-12-19 What do people love about Rust?
  [*] [2] 2025-12-16 Project goals update — November 2025
  ...
```

## 学べるRustの概念
- 文字列処理（`split`、`trim`、`join`）
- イテレータとクロージャ（`map`、`collect`）
- SQLクエリの動的構築
- パラメータ化クエリによるセキュリティ対策
- `Option`型の活用（`if let Some(...)`）

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)